### PR TITLE
Running python cli tool inside a docker container

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Moger Tests
 on:
   push:
     branches: ["main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
 FROM python:3.10.13-bullseye
 
+
+ARG MOGER_CLI_HOME=/usr/local/moger
+WORKDIR ${MOGER_CLI_HOME}
+RUN pip install poetry==1.6.1
+
 COPY . .
 
-RUN pip install poetry==1.6.1
+# Installs the moger python package globally
+RUN cd ${MOGER_CLI_HOME} && \
+    poetry config virtualenvs.create false && \  
+    poetry install
+
+ENV PYTHONPATH=/usr/local/moger
+
+ENTRYPOINT ["moger"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
+## Installation
+
+![Build Status](https://github.com/kenyaachon/moger/actions/workflows/tests.yml/badge.svg?branch=main)
+
+As of right now, moger CLI only supports MacOS, and Linux systems
+
+`./bin/install.sh`
+
 ## Development
 
-`poetry run python moger/main.py`
+`poetry run moger`
+
+### Docker
+
+- Building Docker Image
+  `docker build --tag moger .`
+- Running Docker Image
+  `docker run moger login`
+
+### Moger Initialization
+
+`poetry run moger init`
+
+### Moger Login
+
+`poetry run moger login non-prod`

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# moger CLI installation
+
+
+echo "Starting the moger CLI installation"
+echo
+
+echo "-- Checking if user has sudo access"
+sudo -v
+if [ $? -ne 0 ]; then
+    echo "Current user does not have sudo access"
+    exit 1
+fi
+echo
+
+echo "-- Checking if docker is installed"
+docker --version
+if [ $? -ne 0 ]; then
+    echo "The docker CLI is not installed"
+    exit 1
+fi
+echo
+
+
+set -e
+
+echo "-- Installing moger CLI wrapper"
+sudo cp -f bin/moger.sh /usr/local/bin/moger
+sudo chmod 755 /usr/local/bin/moger
+echo
+
+echo "-- Finished installing moger CLI" 

--- a/bin/moger.sh
+++ b/bin/moger.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# moger CLI wrapper
+
+set -e
+echo "Here is my moger CLI"
+
+IMAGE="moger"
+DOCKER_EXTRA_ARGS=${DOCKER_EXTRA_ARGS:-""}
+
+
+if [[ $OSTYPE =~ ^darwin ]]; then
+    echo "Spawning moger CLI docker container"
+
+    docker run --rm -it \
+        -v $(pwd):/workspace \
+        -v /var/run/dokcer.sock:/var/run/docker.sock \
+        ${DOCKER_EXTRA_ARGS} ${IMAGE} $*
+else
+    echo "Unsupported OS version: ${OSTYPE}"
+    exit 1
+fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ typer = {extras = ["all"], version = "^0.9.0"}
 pytest = "^7.4.3"
 black = "^23.10.1"
 mypy = "^1.6.1"
+[tool.poetry.scripts]
+moger = 'moger.main:app'
+
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
# Requirements
The initial requirement for the moger cli tool is to run across all linux based environments
Since not all environments are the same, using docker container ensures that moger tool will across to reduce the amount of time it takes to setup the moger cli tool to a matter of minutes.
In this release


# Testing
```
./bin/install.sh
docker build --tag moger .
moger init
```

